### PR TITLE
Fix URL encoding

### DIFF
--- a/.azure-devops/component-governance.yaml
+++ b/.azure-devops/component-governance.yaml
@@ -14,7 +14,7 @@ steps:
 
   - task: PipAuthenticate@1
     inputs:
-      artifactFeeds: "Analysis%20and%20Experimentation/Analysis_and_Experimentation_PublicPackages"
+      artifactFeeds: "Analysis and Experimentation/Analysis_and_Experimentation_PublicPackages"
 
   - script: |
       python -m pip install --upgrade pip


### PR DESCRIPTION
The PipAuthenticate task performs its own URL encoding, so we're currently using %2520 instead of %20.