### PR TITLE
Expose ScorecardId in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The analysis results are summarized as a GitHub Flavored Markdown document for a
 
 | Name                | Description                                                        |
 | :------------------ | :----------------------------------------------------------------- |
+| allocation-id       | Identifier for the experiment configuration.                       |
+| scorecard-id        | Identifier for the experiment analysis.                            |
 | analysis-start-time | The start time of the analysis (ISO 8601 format).                  |
 | analysis-end-time   | The end time of the analysis (ISO 8601 format).                    |
 | summary-md          | Summary of the analysis results (GitHub Flavored Markdown format). |

--- a/action.py
+++ b/action.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
     if results.scorecard.empty:
         raise ValueError("Found analysis results but unable to download metric data")
 
+    set_github_output("allocation-id", results.analysis.allocation_id)
+    set_github_output("scorecard-id", results.analysis.scorecard_id)
     set_github_output("analysis-start-time", results.analysis.start_time.isoformat())
     set_github_output("analysis-end-time", results.analysis.end_time.isoformat())
     set_github_output("summary-md", summary_md)

--- a/analysis/summary-ab.md.jinja
+++ b/analysis/summary-ab.md.jinja
@@ -32,6 +32,7 @@ n/a
 * ✨ **Feature flag:** {{ analysis.feature_flag }}
 * 🔬 **Allocation ID:** {{ analysis.allocation_id }}
 * 📅 **Analysis period:** {{ '{:.1f}'.format((analysis.end_time - analysis.start_time).total_seconds() / (24 * 60 * 60)) }} days ({{ analysis.start_time.strftime("%m/%d/%Y %H:%M") }} - {{ analysis.end_time.strftime("%m/%d/%Y %H:%M") }} UTC)
+* 🔖 **Scorecard ID:** {{ analysis.scorecard_id }}
 
 ### Summary of variants
 

--- a/tests/snapshots/integration/multi-metric-multi-treatment/output.md
+++ b/tests/snapshots/integration/multi-metric-multi-treatment/output.md
@@ -5,6 +5,7 @@
 * ✨ **Feature flag:** test_feature
 * 🔬 **Allocation ID:** test_allocation
 * 📅 **Analysis period:** 30.0 days (01/01/2024 00:00 - 01/31/2024 00:00 UTC)
+* 🔖 **Scorecard ID:** test_scorecard
 
 ### Summary of variants
 

--- a/tests/snapshots/integration/multi-metric-single-treatment/output.md
+++ b/tests/snapshots/integration/multi-metric-single-treatment/output.md
@@ -5,6 +5,7 @@
 * ✨ **Feature flag:** test_feature
 * 🔬 **Allocation ID:** test_allocation
 * 📅 **Analysis period:** 30.0 days (01/01/2024 00:00 - 01/31/2024 00:00 UTC)
+* 🔖 **Scorecard ID:** test_scorecard
 
 ### Summary of variants
 

--- a/tests/snapshots/integration/single-metric-multi-treatment/output.md
+++ b/tests/snapshots/integration/single-metric-multi-treatment/output.md
@@ -5,6 +5,7 @@
 * ✨ **Feature flag:** test_feature
 * 🔬 **Allocation ID:** test_allocation
 * 📅 **Analysis period:** 30.0 days (01/01/2024 00:00 - 01/31/2024 00:00 UTC)
+* 🔖 **Scorecard ID:** test_scorecard
 
 ### Summary of variants
 

--- a/tests/snapshots/integration/single-metric-single-treatment/output.md
+++ b/tests/snapshots/integration/single-metric-single-treatment/output.md
@@ -5,6 +5,7 @@
 * ✨ **Feature flag:** test_feature
 * 🔬 **Allocation ID:** test_allocation
 * 📅 **Analysis period:** 30.0 days (01/01/2024 00:00 - 01/31/2024 00:00 UTC)
+* 🔖 **Scorecard ID:** test_scorecard
 
 ### Summary of variants
 


### PR DESCRIPTION
* Expose Scorecard ID in analysis metadata section of markdown summary
* Add action outputs: `allocation-id` and `scorecard-id`