### PR TITLE
Hide the commit hash found in metric descriptions

### DIFF
--- a/analysis/render.py
+++ b/analysis/render.py
@@ -248,6 +248,12 @@ def fmt_metric_table(df: pd.DataFrame) -> str:
     )
 
 
+def strip_commit_hash(description: str) -> str:
+    """Strip commit hash from a metric description"""
+    marker = "Commit hash:"
+    return description.split(marker)[0].strip()
+
+
 def fmt_metric_search(
     metric_id: str, text: str = "Search for metric definition."
 ) -> str:
@@ -275,6 +281,7 @@ def summarize(
 
     template = env.get_template("summary-ab.md.jinja")
     template.globals.update(fmt_metric_table=fmt_metric_table)
+    template.globals.update(strip_commit_hash=strip_commit_hash)
     template.globals.update(fmt_metric_search=fmt_metric_search)
     template.globals.update(fmt_badge=fmt_badge)
 

--- a/analysis/summary-ab.md.jinja
+++ b/analysis/summary-ab.md.jinja
@@ -74,7 +74,7 @@ n/a
 > <summary><strong>Metric details</strong></summary>
 >
 {% for _, metric in df_tag[["MetricId", "MetricDisplayName", "MetricDescription"]].drop_duplicates().iterrows() -%}
-> * ***{{ metric.MetricDisplayName }}:*** {{ metric.MetricDescription }} {{ fmt_metric_search(metric.MetricId) }}</dd>
+> * ***{{ metric.MetricDisplayName }}:*** {{ strip_commit_hash(metric.MetricDescription) }} {{ fmt_metric_search(metric.MetricId) }}</dd>
 {% endfor -%}
 >
 > </details>

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -19,6 +19,7 @@ from analysis.render import (
     fmt_pvalue,
     fmt_reldiff,
     fmt_treatment_badge,
+    strip_commit_hash,
 )
 
 
@@ -279,6 +280,15 @@ def test_fmt_metric_table(test_case, data, snapshot):
 
     snapshot.snapshot_dir = Path("tests", "snapshots", "fmt_metric_table")
     snapshot.assert_match(output, f"{test_case}.md")
+
+
+def test_strip_commit_hash():
+    """Test stripping the optional commit hash from the metric description."""
+    with_hash = "Metric description Commit hash: 123456789"
+    without_hash = "Metric description"
+
+    assert strip_commit_hash(with_hash) == "Metric description"
+    assert strip_commit_hash(without_hash) == "Metric description"
 
 
 def test_fmt_metric_search_enabled(monkeypatch):


### PR DESCRIPTION
The azure/online-experimentation-deploy-metrics action has an `add-commit-hash-to-metric-description` input to append the git commit hash to the description of each deployed metric. This is a useful feature for metric versioning, but it's confusing when reviewing the analysis results in the markdown summary. We now strip this info before showing the metric description in the markdown.

Depends on https://github.com/Azure/online-experimentation-deploy-metrics/pull/13